### PR TITLE
fix(school-house): stop resetting quiz timer on tab visibility change

### DIFF
--- a/src/components/school-house/hooks/useSchoolChallenge.js
+++ b/src/components/school-house/hooks/useSchoolChallenge.js
@@ -82,17 +82,6 @@ export default function useSchoolChallenge() {
   }, [currentQuestionIndex])
 
   useEffect(() => {
-    function handleVisibilityChange() {
-      if (document.visibilityState === 'visible') {
-        setSecondsLeft(QUESTION_TIME_SECONDS)
-      }
-    }
-
-    document.addEventListener('visibilitychange', handleVisibilityChange)
-    return () => document.removeEventListener('visibilitychange', handleVisibilityChange)
-  }, [])
-
-  useEffect(() => {
     if (activeSection !== 'quiz' || isSubmitted || secondsLeft === 0) return undefined
 
     const timerId = window.setInterval(() => {


### PR DESCRIPTION
Removed the visibilitychange listener in useSchoolChallenge that force-reset secondsLeft to QUESTION_TIME_SECONDS whenever the tab became visible again. This allowed players to refill the quiz timer indefinitely by switching tabs.

The existing setInterval countdown already handles tab backgrounding via native browser throttling, so no replacement logic is needed.