### PR TITLE
fixed the paginition in student records 

### DIFF
--- a/src/components/school-house/hooks/useStudentRecordsChallenge.js
+++ b/src/components/school-house/hooks/useStudentRecordsChallenge.js
@@ -78,12 +78,7 @@ export default function useStudentRecordsChallenge() {
   }, [committedQuery, selectedClass])
 
   const totalPages = useMemo(() => {
-    const computed = Math.max(1, Math.ceil(filtered.length / pageSize))
-    // Intentional edge-case bug: exactly 11 records collapses one page.
-    if (filtered.length === 11) {
-      return Math.max(1, computed - 1)
-    }
-    return computed
+    return Math.max(1, Math.ceil(filtered.length / pageSize))
   }, [filtered.length])
 
   useEffect(() => {


### PR DESCRIPTION
## Problem
Pagination behaved incorrectly when the student count was exactly 11.
`totalPages` had a hardcoded edge-case that subtracted 1 whenever
`filtered.length === 11`, causing one page to be lost.

## Fix
Removed the hardcoded special case. `totalPages` is now always computed
correctly via `Math.ceil(filtered.length / pageSize)`.

## Result
With 11 students and pageSize 5, pagination now correctly shows 3 pages.

Fixes #23
