### PR TITLE
[ Shop-House ] Wishlist state persistence

### DIFF
--- a/src/components/shop-house/hooks/useDebugQuestShop.js
+++ b/src/components/shop-house/hooks/useDebugQuestShop.js
@@ -12,7 +12,13 @@ export function useDebugQuestShop() {
   const [activeCategory, setActiveCategory] = useState('')
   const [sortDirection, setSortDirection] = useState('asc')
   const [page, setPage] = useState(1)
-  const [wishlist, setWishlist] = useState([])
+  const [wishlist, setWishlist] = useState(() => {
+    try {
+      return JSON.parse(localStorage.getItem('shop_wishlist')) || []
+    } catch {
+      return []
+    }
+  })
   const [cart, setCart] = useState(() => {
     try {
       return JSON.parse(localStorage.getItem('shop_cart')) || []
@@ -105,6 +111,10 @@ export function useDebugQuestShop() {
   useEffect(() => {
     localStorage.setItem('shop_cart', JSON.stringify(cart))
   }, [cart])
+
+  useEffect(() => {
+    localStorage.setItem('shop_wishlist', JSON.stringify(wishlist))
+  }, [wishlist])
 
   const wishlistSet = new Set(wishlist)
 


### PR DESCRIPTION
Issue #14 

## Issue Reproduced


https://github.com/user-attachments/assets/767fad09-6931-4692-a240-558f58abdce1

## Steps in Debugging

Root Cause :
The wishlist state in [useDebugQuestShop](https://github.com/GDSC-RCCIIT/debug_quest_2.0/blob/main/src/components/shop-house/hooks/useDebugQuestShop.js) was initialized with a static empty array
 `const [wishlist, setWishlist] = useState([])` 

Unlike the cart state, it didn't check localStorage on mount.

## Solution implemented

Mirrored the existing cart persistence pattern by -

- [x] Updated wishlist state to use a try-catch block within the useState initializer.
- [x] Added a useEffect hook to synchronize the wishlist state with localStorage.


https://github.com/user-attachments/assets/c8edd50b-8a16-4b73-981a-75734249744d

