### PR TITLE
Improve inventory accuracy

### DIFF
--- a/src/components/ShopHouse.css
+++ b/src/components/ShopHouse.css
@@ -353,6 +353,11 @@
   color: #f7d27d;
 }
 
+.stock-badge.out {
+  border-color: #f43f5e;
+  color: #ff6b7a;
+}
+
 .cart-action {
   border: 1px solid #4a77b8;
   border-radius: 10px;

--- a/src/components/ShopHouse.jsx
+++ b/src/components/ShopHouse.jsx
@@ -56,6 +56,7 @@ export default function ShopHouse({ onBack }) {
               products={shop.pagedProducts}
               isLoadingProducts={shop.isLoadingProducts}
               wishlistSet={shop.wishlistSet}
+              cartQtyMap={shop.cartQtyMap}
               onToggleWishlist={shop.toggleWishlist}
               onAddToCart={shop.addToCart}
               onOpenProductModal={shop.openProductModal}

--- a/src/components/shop-house/ProductGrid.jsx
+++ b/src/components/shop-house/ProductGrid.jsx
@@ -62,6 +62,7 @@ export default function ProductGrid({
                   type="button"
                   className="cart-action glitch"
                   onClick={() => onAddToCart(product)}
+                  disabled={availableStock <= 0}
                 >
                   Add To Cart
                 </button>

--- a/src/components/shop-house/ProductGrid.jsx
+++ b/src/components/shop-house/ProductGrid.jsx
@@ -4,6 +4,7 @@ export default function ProductGrid({
   products,
   isLoadingProducts,
   wishlistSet,
+  cartQtyMap,
   onToggleWishlist,
   onAddToCart,
   onOpenProductModal,
@@ -18,50 +19,56 @@ export default function ProductGrid({
       ) : null}
 
       <div className="products-grid">
-        {products.map((product) => (
-          <article key={product.id} className="product-card" style={{ '--card-accent': product.accent }}>
-            <button
-              type="button"
-              className="wishlist"
-              onClick={() => onToggleWishlist(product.id)}
-              aria-label={`Wishlist ${product.name}`}
-            >
-              {wishlistSet.has(product.id) ? '♥' : '♡'}
-            </button>
+        {products.map((product) => {
+          const reservedQty = cartQtyMap?.get(product.id) ?? 0
+          const availableStock = Math.max(0, product.stock - reservedQty)
+          const badgeClass = availableStock <= 0 ? 'out' : availableStock <= 3 ? 'low' : ''
 
-            <button type="button" className="media-placeholder" onClick={() => onOpenProductModal(product)}>
-              {product.image ? (
-                <img
-                  src={product.image}
-                  alt={product.name}
-                  style={{ width: '100%', height: '100%', objectFit: 'cover', borderRadius: 'inherit' }}
-                />
-              ) : (
-                <span>IMG</span>
-              )}
-            </button>
-
-            <div className="product-meta">
-              <h3>
-                <button type="button" className="title-link" onClick={() => onOpenProductModal(product)}>
-                  {product.name}
-                </button>
-              </h3>
-              <p>{formatINR(product.price)}</p>
-            </div>
-
-            <div className="card-bottom">
-              <span className={`stock-badge ${product.stock <= 3 ? 'low' : ''}`}>{stockLabel(product.stock)}</span>
+          return (
+            <article key={product.id} className="product-card" style={{ '--card-accent': product.accent }}>
               <button
                 type="button"
-                className="cart-action glitch"
-                onClick={() => onAddToCart(product)}
+                className="wishlist"
+                onClick={() => onToggleWishlist(product.id)}
+                aria-label={`Wishlist ${product.name}`}
               >
-                Add To Cart
+                {wishlistSet.has(product.id) ? '♥' : '♡'}
               </button>
-            </div>
-          </article>
-        ))}
+
+              <button type="button" className="media-placeholder" onClick={() => onOpenProductModal(product)}>
+                {product.image ? (
+                  <img
+                    src={product.image}
+                    alt={product.name}
+                    style={{ width: '100%', height: '100%', objectFit: 'cover', borderRadius: 'inherit' }}
+                  />
+                ) : (
+                  <span>IMG</span>
+                )}
+              </button>
+
+              <div className="product-meta">
+                <h3>
+                  <button type="button" className="title-link" onClick={() => onOpenProductModal(product)}>
+                    {product.name}
+                  </button>
+                </h3>
+                <p>{formatINR(product.price)}</p>
+              </div>
+
+              <div className="card-bottom">
+                <span className={`stock-badge ${badgeClass}`}>{stockLabel(availableStock)}</span>
+                <button
+                  type="button"
+                  className="cart-action glitch"
+                  onClick={() => onAddToCart(product)}
+                >
+                  Add To Cart
+                </button>
+              </div>
+            </article>
+          )
+        })}
       </div>
     </>
   )

--- a/src/components/shop-house/data.js
+++ b/src/components/shop-house/data.js
@@ -36,6 +36,7 @@ export function formatINR(value) {
 }
 
 export function stockLabel(stock) {
+  if (stock <= 0) return 'OUT OF STOCK'
   if (stock <= 3) return 'LOW STOCK'
   return 'IN STOCK'
 }

--- a/src/components/shop-house/hooks/useDebugQuestShop.js
+++ b/src/components/shop-house/hooks/useDebugQuestShop.js
@@ -150,6 +150,8 @@ export function useDebugQuestShop() {
     return Math.max(0, subtotal - discountValue)
   }, [subtotal])
 
+  const cartQtyMap = useMemo(() => new Map(cart.map((entry) => [entry.id, entry.qty])), [cart])
+
   const checkoutStockMap = useMemo(() => {
     return new Map(renderedProducts.map((item) => [item.id, item.stock]))
   }, [renderedProducts])
@@ -309,6 +311,7 @@ export function useDebugQuestShop() {
     subtotal,
     discountValue,
     total,
+    cartQtyMap,
     onSearchChange,
     onCategoryChange,
     onSortChange,


### PR DESCRIPTION
## Bug Report:


https://github.com/user-attachments/assets/7d37e220-24b1-4c6b-8d4d-35035fa05464


- The UI displayed total warehouse stock rather than "true" available stock 

Previously, the Low Stock and Out of Stock states were unreachable if a user filled their cart. Because the UI only looked at total warehouse inventory, a product would still appear as 'In Stock' even if the user had claimed every available unit in their session.
- UI failed to reflect Inventory Exhaustion

Thus we introduces a three-tier (instead of 2) stock status system (In Stock, Low Stock, and **Out of Stock**)

## Solution:

- [x] Introduced `cartQtyMap` to track items currently in the user's session.
- [x] Added a derived state for availableStock - `availableStock = max(0, total_stock - reserved_qty)`
- [x] Updated the "Add to Cart" button to include a `disabled` state when stock hits zero. 

## Working 


https://github.com/user-attachments/assets/fe7e2547-8392-4f92-b1ba-7819f885006a

