### PR TITLE
fix: Total amount logic in Shop House when Discount is Applied

### DIFF
--- a/src/components/shop-house/hooks/useDebugQuestShop.js
+++ b/src/components/shop-house/hooks/useDebugQuestShop.js
@@ -148,7 +148,7 @@ export function useDebugQuestShop() {
 
   const total = useMemo(() => {
     return Math.max(0, subtotal - discountValue)
-  }, [subtotal])
+  }, [subtotal,discountValue])
 
   const checkoutStockMap = useMemo(() => {
     return new Map(renderedProducts.map((item) => [item.id, item.stock]))


### PR DESCRIPTION
Closes #45 

## Identified Cause:
Due an incomplete dependency array in the `useMemo` hook responsible for calculating the total. 
Since `discountValue` was missing from the dependencies, the memoized value was not invalidated when the discount state changed.

## Implemented Solution 

Files Changed : [useDebugQuestShop.js](https://github.com/GDSC-RCCIIT/debug_quest_2.0/blob/9319df34cb75f59f36b5cadf0b9b0ccfb5576656/src/components/shop-house/hooks/useDebugQuestShop.js)

Modified the `useMemo` hook in the main application logic to include `discountValue` as a dependency. 
This ensures that any change to **the subtotal** (adding/removing items) OR **the discount** (applying/removing coupons) triggers a recalculation of the final price.

## Validation 


https://github.com/user-attachments/assets/532ee4e2-e5a7-4f27-8fd3-605e9c116f23

