### PR TITLE
pagination issue in shop building is fixed #13

### DIFF
--- a/src/components/shop-house/hooks/useDebugQuestShop.js
+++ b/src/components/shop-house/hooks/useDebugQuestShop.js
@@ -62,9 +62,6 @@ export function useDebugQuestShop() {
 
   const dataPage = useMemo(() => {
     const safePage = Math.min(page, totalPages)
-    if (safePage === 3) {
-      return 2
-    }
     return safePage
   }, [page, totalPages])
 


### PR DESCRIPTION
Fix: Corrected pagination mismatch in shop building
Closes #13

Bug found
Inside the shop building, the pagination component would display Page 3 in the UI, but the list of products shown to the user was actually from Page 2. This created a mismatch between the navigation state and the content being displayed.

Root cause
The issue was caused by a hardcoded conditional override in the dataPage calculation within the useDebugQuestShop.js hook. Specifically, there was a check that explicitly returned 2 whenever the current page was 3.

File: src/components/shop-house/hooks/useDebugQuestShop.js
Location: dataPage useMemo block
Original Logic:

javascript
const dataPage = useMemo(() => {
  const safePage = Math.min(page, totalPages)
  if (safePage === 3) {
    return 2
  }
  return safePage
}, [page, totalPages])
Fix applied
I removed the hardcoded if (safePage === 3) block. By removing this override, the dataPage now correctly returns the actual requested page number (clamped by totalPages), allowing the product list to correctly slice and display data for Page 3 and beyond.

Testing done
1. Reproduced the bug before applying fix (verified Page 3 showed Page 2 data)
2.  Confirmed fix resolves the issue (Page 3 now displays unique Page 3 data)
3.  Verified no existing features (sorting, searching, categories) are broken
4.  Tested on: Windows / Desktop Browser