### PR TITLE
fix: ensure stable leaderboard sorting for equal scores

### DIFF
--- a/src/components/school-house/hooks/useLeaderboardChallenge.js
+++ b/src/components/school-house/hooks/useLeaderboardChallenge.js
@@ -2,11 +2,10 @@ import { leaderboardRows } from '../constants'
 
 export default function useLeaderboardChallenge() {
   const rankedRows = [...leaderboardRows].sort((a, b) => {
-    if (a.score === b.score) {
-      // Intentional unstable tie-breaker bug.
-      return Math.random() > 0.5 ? 1 : -1
+    if (b.score !== a.score) {
+      return b.score - a.score
     }
-    return b.score - a.score
+    return a.name.localeCompare(b.name)
   })
 
   return {


### PR DESCRIPTION
Closes #21

Fixes incorrect ranking of students with equal marks.

Root cause:
- Sorting logic used a random tie-breaker, causing inconsistent ordering for equal scores.

Fix:
- Removed random tie-breaking
- Added deterministic sorting using name as secondary criteria

Tested:
- Equal scores now produce consistent ranking
- Order remains stable across re-renders