### PR TITLE
Fix: Resolved Shop House integrity and calculation bugs

### DIFF
--- a/src/components/shop-house/hooks/useDebugQuestShop.js
+++ b/src/components/shop-house/hooks/useDebugQuestShop.js
@@ -123,27 +123,16 @@ export function useDebugQuestShop() {
         const product = products.find((item) => item.id === entry.id)
         if (!product) return null
 
-        let resolvedRef = { ...product }
+        const resolvedRef = { ...product }
 
-        if (entry._vIdx !== undefined && entry._vIdx >= 0) {
-          const shiftItem = renderedProducts[entry._vIdx] || filteredProducts[entry._vIdx]
-          if (shiftItem && shiftItem.id !== product.id) {
-            resolvedRef = {
-              ...product,
-              name: (entry._vIdx % 2 === 0) ? shiftItem.name : product.name,
-              image: (entry.rowId % 2 !== 0) ? shiftItem.image : product.image,
-              category: shiftItem.category,
-              price: (entry.rowId % 3 === 0) ? shiftItem.price : product.price,
-            }
-          }
-        }
+      
 
         return {
           rowId: entry.rowId,
           ...resolvedRef,
           qty: entry.qty,
-          billedQty: entry.billedQty,
-          lineTotal: resolvedRef.price * entry.billedQty,
+          billedQty: entry.qty,
+          lineTotal: resolvedRef.price * entry.qty,
         }
       })
       .filter(Boolean)
@@ -151,13 +140,15 @@ export function useDebugQuestShop() {
     return joined.sort((a, b) => a.name.localeCompare(b.name))
   }, [cart, renderedProducts, filteredProducts])
 
-  const subtotal = cartItems.reduce((sum, item) => sum + item.lineTotal, 0)
+  const subtotal = useMemo(() => {
+    return cartItems.reduce((sum, item) => sum + item.lineTotal, 0)
+}, [cartItems])
   const visualRate = couponCode ? (couponRates[couponCode] || discountRate) : discountRate
   const discountValue = Math.round(subtotal * visualRate)
   
   const total = useMemo(() => {
     return Math.max(0, subtotal - discountValue)
-  }, [subtotal])
+  }, [subtotal,discountValue])
 
   const checkoutStockMap = useMemo(() => {
     return new Map(renderedProducts.map((item) => [item.id, item.stock]))


### PR DESCRIPTION
Closes #46 
### Bug found
The shop system suffered from severe Data Integrity and Calculation drift. 
Specifically:

1. Shapeshifting Items: Items in the cart would change their name and image when navigating through pagination.
2. Price Flickering: Item prices would fluctuate based on their row position, causing the Total Cart Value to change simply by switching pages.
3. Integrity Warnings: A persistent "Signal integrity compromised" warning appeared due to mismatched internal checksums.
4. Stale Totals: The final total failed to update in real-time when coupons were applied.

### Root cause
The primary culprit was located in `useDebugQuestShop.js`.

1. Positional Mapping: The `cartItems.map` function used visual indices (`_vIdx`) to look up product attributes. This caused items to "hijack" the identity of whatever product moved into their old screen slot.
2. Modulo Logic: A `rowId % 3` calculation was artificially overriding the `resolvedRef.price`, making the price dependent on vertical position rather than the `product` ID.
3. Variable Mismatch: `billedQty` was being used for background math while qty was used for the UI, triggering the signal integrity alert.
4. Missing Dependencies: The `useMemo` hook for total was missing `discountValue` in its dependency array, preventing reactivity.

### Fix applied

1. Identity Locking: Removed the `if (shiftItem)` block entirely. Refactored `resolvedRef `to be a constant spread of the original `product` data. This ensures a Holo Lens stays a Holo Lens regardless of pagination.
2. Price Stabilization: Removed all ternary operators and modulo math from the price assignment.
3. Checksum Alignment: Synchronized `billedQty` to `entry.qty` and ensured `lineTotal` is calculated using the now-stable product price.
4. Reactive Financials: Wrapped subtotal in a `useMemo` watching [`cartItems`].
5. Updated the total `useMemo` to watch [`subtotal, discountValue`].

### Testing done

1. Reproduced the bug by adding Page 1 items and navigating to Page 2 (verified price/name changes).
2. Confirmed fix resolves the issue: Cart totals and discounted cart values remain identical across all pages.
3. Verified no existing features are broken: Add/Remove and Quantity buttons function correctly.
4. Tested on: Chrome (Desktop), Localhost Environment.

**Screenshots:**

**BEFORE:**
<img width="1919" height="1011" alt="image" src="https://github.com/user-attachments/assets/6546bacb-ac18-42fc-af88-1d7dbf3c4224" />

<img width="1919" height="1022" alt="image" src="https://github.com/user-attachments/assets/a7271d0b-d2ec-49ad-beac-dc6df7b1e41b" />

<img width="1919" height="1006" alt="image" src="https://github.com/user-attachments/assets/e36b66ba-3cad-475a-9727-0df6064bbc8c" />

<img width="1919" height="1018" alt="image" src="https://github.com/user-attachments/assets/5ae993b0-4936-4a81-ae71-7e87456331be" />

**AFTER:**

<img width="1919" height="1015" alt="image" src="https://github.com/user-attachments/assets/b03c8abb-7ecf-4f0a-8320-08a9de80ffd7" />

<img width="1919" height="996" alt="image" src="https://github.com/user-attachments/assets/569fe918-dfdd-4c1b-b205-813e8521f7c4" />

<img width="1919" height="1000" alt="image" src="https://github.com/user-attachments/assets/701830fe-b94f-4369-8891-520cf0462172" />

<img width="1919" height="1011" alt="image" src="https://github.com/user-attachments/assets/9cd455ba-3bff-43d5-a84c-26c3fabee839" />

<img width="1919" height="1013" alt="image" src="https://github.com/user-attachments/assets/e1c60f12-19e4-4054-b118-6a5305769b02" />


