### PR TITLE
Fix practice room timer pause functionality

### DIFF
--- a/src/components/school-house/hooks/usePracticeRoomChallenge.js
+++ b/src/components/school-house/hooks/usePracticeRoomChallenge.js
@@ -19,7 +19,7 @@ export default function usePracticeRoomChallenge() {
   const currentQuestion = questionSet[currentIndex] ?? questionSet[0]
 
   useEffect(() => {
-    if (!isRunning) return undefined
+    if (!isRunning || isPaused) return undefined
 
     const timerId = window.setInterval(() => {
       setSecondsLeft((previous) => {
@@ -32,7 +32,7 @@ export default function usePracticeRoomChallenge() {
     }, 1000)
 
     return () => window.clearInterval(timerId)
-  }, [isRunning])
+  }, [isRunning, isPaused])
 
   const displayedSeconds = isPaused ? pausedDisplayTime : secondsLeft
 


### PR DESCRIPTION
### Issue #65 Fixed
School House — Practice Room Timer Doesn't Pause

### What was fixed
Clicking the pause button in the Practice Room did not actually stop the countdown timer. The timer kept running in the background even when paused, causing the session to expire unexpectedly.

### Root cause
In usePracticeRoomChallenge.js, the useEffect that controls the timer interval only checked isRunning but ignored the isPaused state:
```
if (!isRunning) return undefined
// ...
}, [isRunning])
```

This meant the interval kept ticking even when isPaused was true.

### Approach / Solution
Added isPaused to both the early-return guard and the dependency array so the timer effect properly stops when paused:

1. Added isPaused check: if (!isRunning || isPaused) return undefined
2. Added isPaused to the dependency array: [isRunning, isPaused]
3. No other behavior touched (leaderboard, quiz arena, student records untouched)
4. No new dependencies

### Files changed
usePracticeRoomChallenge.js

### Testing
Open School House → Practice Room → Start a session → Click Pause.
The timer now freezes immediately and resumes correctly when unpaused.