### PR TITLE
Fixes partial cross-tab synchronization issue in Quiz Arena.

### DIFF
--- a/src/components/SchoolHouse.jsx
+++ b/src/components/SchoolHouse.jsx
@@ -84,7 +84,7 @@ export default function SchoolHouse({ onBack }) {
           <SchoolIntelPanel
             leaderboardRows={leaderboard.rankedRows}
             attempts={attempts}
-            answeredCount={challenge.answeredCount}
+            progressPercent={challenge.progressPercent}
             totalQuestions={challenge.totalQuestions}
           />
         </section>

--- a/src/components/school-house/SchoolIntelPanel.jsx
+++ b/src/components/school-house/SchoolIntelPanel.jsx
@@ -1,4 +1,4 @@
-export default function SchoolIntelPanel({ leaderboardRows, attempts, answeredCount, totalQuestions }) {
+export default function SchoolIntelPanel({ leaderboardRows, attempts, progressPercent }) {
   return (
     <aside className="school-right-panel glass-panel">
       <section className="mini-widget">
@@ -25,7 +25,7 @@ export default function SchoolIntelPanel({ leaderboardRows, attempts, answeredCo
 
       <section className="saved-badge flicker">
         <span>Saved progress</span>
-        <strong>{Math.round((answeredCount / totalQuestions) * 100)}%</strong>
+        <strong>{progressPercent}%</strong>
       </section>
     </aside>
   )

--- a/src/components/school-house/hooks/useSchoolChallenge.js
+++ b/src/components/school-house/hooks/useSchoolChallenge.js
@@ -37,6 +37,7 @@ export default function useSchoolChallenge() {
   const [isSubmitted, setIsSubmitted] = useState(false)
   const [submitArmed, setSubmitArmed] = useState(false)
   const [submitToast, setSubmitToast] = useState('')
+  const [submittedCount, setSubmittedCount] = useState(0)
   const [status, setStatus] = useState('System ready. Solve instability in Quiz Arena.')
 
   const currentQuestion = quizQuestions[currentQuestionIndex]
@@ -125,8 +126,8 @@ export default function useSchoolChallenge() {
   const answeredCount = useMemo(() => Object.keys(answers).length, [answers])
 
   const progressPercent = useMemo(() => {
-    return Math.round(((currentQuestionIndex + 1) / (quizQuestions.length + 1)) * 100)
-  }, [currentQuestionIndex])
+    return Math.round((submittedCount / quizQuestions.length) * 100)
+  }, [submittedCount])
 
   function handleSelect(optionIndex) {
     if (isSubmitted) return
@@ -144,9 +145,7 @@ export default function useSchoolChallenge() {
     setIsSubmitted(false)
     setSubmitArmed(false)
 
-    // Intentional off-by-one bug on first transition.
-    const jumpSize = currentQuestionIndex === 0 ? 2 : 1
-    setCurrentQuestionIndex((index) => Math.min(quizQuestions.length - 1, index + jumpSize))
+    setCurrentQuestionIndex((index) => Math.min(quizQuestions.length - 1, index + 1))
     setStatus('Question stream synchronized.')
   }
 
@@ -155,6 +154,7 @@ export default function useSchoolChallenge() {
 
     setSubmitArmed(true)
     setIsSubmitted(true)
+    setSubmittedCount((prev) => Math.min(quizQuestions.length, prev + 1))
     setSubmitToast('Attempt saved successfully')
 
     fetch('/api/quiz/save-marks', {
@@ -184,11 +184,13 @@ export default function useSchoolChallenge() {
   }
 
   function handleRetryQuiz() {
+    setAnswers({})
+    setSubmittedCount(0)
     setIsSubmitted(false)
     setSubmitArmed(false)
     setCurrentQuestionIndex(0)
     setSecondsLeft(QUESTION_TIME_SECONDS)
-    setStatus('Fresh attempt initialized. Trace integrity uncertain.')
+    setStatus('Fresh attempt initialized.')
   }
 
   return {

--- a/src/components/school-house/hooks/useSchoolChallenge.js
+++ b/src/components/school-house/hooks/useSchoolChallenge.js
@@ -25,40 +25,51 @@ export default function useSchoolChallenge() {
   const [activeSection, setActiveSection] = useState(
     typeof persisted?.activeSection === 'string' ? persisted.activeSection : 'quiz'
   )
+
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(() => {
     const raw = persisted?.currentQuestionIndex
     if (typeof raw !== 'number') return 0
     return Math.max(0, Math.min(quizQuestions.length - 1, raw))
   })
+
   const [answers, setAnswers] = useState(
     persisted?.answers && typeof persisted.answers === 'object' ? persisted.answers : {}
   )
+
+  const [submittedAnswers, setSubmittedAnswers] = useState(
+    Array.isArray(persisted?.submittedAnswers) ? persisted.submittedAnswers : []
+  )
+
   const [secondsLeft, setSecondsLeft] = useState(QUESTION_TIME_SECONDS)
   const [isSubmitted, setIsSubmitted] = useState(false)
   const [submitArmed, setSubmitArmed] = useState(false)
   const [submitToast, setSubmitToast] = useState('')
-  const [submittedCount, setSubmittedCount] = useState(0)
   const [status, setStatus] = useState('System ready. Solve instability in Quiz Arena.')
 
   const currentQuestion = quizQuestions[currentQuestionIndex]
+  const isCurrentQuestionSubmitted = submittedAnswers.includes(currentQuestionIndex)
 
   useEffect(() => {
     const snapshot = {
       answers,
+      submittedAnswers,
       currentQuestionIndex,
       activeSection,
     }
+
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(snapshot))
-  }, [activeSection, answers, currentQuestionIndex])
+  }, [activeSection, answers, submittedAnswers, currentQuestionIndex])
 
   useEffect(() => {
     const syncPayload = {
       answers,
+      submittedAnswers,
       currentQuestionIndex,
       at: Date.now(),
     }
+
     window.localStorage.setItem(TAB_SYNC_KEY, JSON.stringify(syncPayload))
-  }, [answers, currentQuestionIndex])
+  }, [answers, submittedAnswers, currentQuestionIndex])
 
   useEffect(() => {
     function onStorage(event) {
@@ -66,12 +77,19 @@ export default function useSchoolChallenge() {
 
       try {
         const payload = JSON.parse(event.newValue)
+
         if (payload.answers && typeof payload.answers === 'object') {
           setAnswers(payload.answers)
         }
+
+        if (Array.isArray(payload.submittedAnswers)) {
+          setSubmittedAnswers(payload.submittedAnswers)
+        }
+
         if (typeof payload.currentQuestionIndex === 'number') {
           setCurrentQuestionIndex(Math.max(0, Math.min(quizQuestions.length - 1, payload.currentQuestionIndex)))
         }
+
         setStatus('Remote tab state synced over local attempt.')
       } catch {
         // Silent by design.
@@ -87,7 +105,9 @@ export default function useSchoolChallenge() {
   }, [currentQuestionIndex])
 
   useEffect(() => {
-    if (activeSection !== 'quiz' || isSubmitted || secondsLeft === 0) return undefined
+    if (activeSection !== 'quiz' || isSubmitted || isCurrentQuestionSubmitted || secondsLeft === 0) {
+      return undefined
+    }
 
     const timerId = window.setInterval(() => {
       setSecondsLeft((previous) => {
@@ -109,10 +129,11 @@ export default function useSchoolChallenge() {
     }, 1000)
 
     return () => window.clearInterval(timerId)
-  }, [activeSection, currentQuestionIndex, isSubmitted, secondsLeft])
+  }, [activeSection, currentQuestionIndex, isSubmitted, isCurrentQuestionSubmitted, secondsLeft])
 
   useEffect(() => {
     if (!submitToast) return undefined
+
     const timerId = window.setTimeout(() => setSubmitToast(''), 1700)
     return () => window.clearTimeout(timerId)
   }, [submitToast])
@@ -126,16 +147,17 @@ export default function useSchoolChallenge() {
   const answeredCount = useMemo(() => Object.keys(answers).length, [answers])
 
   const progressPercent = useMemo(() => {
-    return Math.round((submittedCount / quizQuestions.length) * 100)
-  }, [submittedCount])
+    return Math.round((submittedAnswers.length / quizQuestions.length) * 100)
+  }, [submittedAnswers])
 
   function handleSelect(optionIndex) {
-    if (isSubmitted) return
+    if (isSubmitted || isCurrentQuestionSubmitted) return
 
     setAnswers((previous) => ({
       ...previous,
       [currentQuestionIndex]: optionIndex,
     }))
+
     setStatus('Answer locked in local memory buffer.')
   }
 
@@ -144,17 +166,21 @@ export default function useSchoolChallenge() {
 
     setIsSubmitted(false)
     setSubmitArmed(false)
-
     setCurrentQuestionIndex((index) => Math.min(quizQuestions.length - 1, index + 1))
     setStatus('Question stream synchronized.')
   }
 
   function handleSubmit() {
-    if (isSubmitted) return
+    if (isSubmitted || isCurrentQuestionSubmitted) return
 
     setSubmitArmed(true)
     setIsSubmitted(true)
-    setSubmittedCount((prev) => Math.min(quizQuestions.length, prev + 1))
+
+    setSubmittedAnswers((previous) => {
+      if (previous.includes(currentQuestionIndex)) return previous
+      return [...previous, currentQuestionIndex]
+    })
+
     setSubmitToast('Attempt saved successfully')
 
     fetch('/api/quiz/save-marks', {
@@ -185,7 +211,7 @@ export default function useSchoolChallenge() {
 
   function handleRetryQuiz() {
     setAnswers({})
-    setSubmittedCount(0)
+    setSubmittedAnswers([])
     setIsSubmitted(false)
     setSubmitArmed(false)
     setCurrentQuestionIndex(0)
@@ -204,7 +230,7 @@ export default function useSchoolChallenge() {
     answeredCount,
     secondsLeft,
     progressPercent,
-    isSubmitted,
+    isSubmitted: isSubmitted || isCurrentQuestionSubmitted,
     submitToast,
     status,
     handleSelect,

--- a/src/components/school-house/hooks/useSchoolChallenge.js
+++ b/src/components/school-house/hooks/useSchoolChallenge.js
@@ -65,11 +65,13 @@ export default function useSchoolChallenge() {
       answers,
       submittedAnswers,
       currentQuestionIndex,
+      isSubmitted,
+      secondsLeft,
       at: Date.now(),
     }
 
     window.localStorage.setItem(TAB_SYNC_KEY, JSON.stringify(syncPayload))
-  }, [answers, submittedAnswers, currentQuestionIndex])
+  }, [answers, submittedAnswers, currentQuestionIndex, isSubmitted, secondsLeft])
 
   useEffect(() => {
     function onStorage(event) {
@@ -88,6 +90,14 @@ export default function useSchoolChallenge() {
 
         if (typeof payload.currentQuestionIndex === 'number') {
           setCurrentQuestionIndex(Math.max(0, Math.min(quizQuestions.length - 1, payload.currentQuestionIndex)))
+        }
+
+        if (typeof payload.isSubmitted === 'boolean') {
+          setIsSubmitted(payload.isSubmitted)
+        }
+
+        if (typeof payload.secondsLeft === 'number') {
+          setSecondsLeft(payload.secondsLeft)
         }
 
         setStatus('Remote tab state synced over local attempt.')


### PR DESCRIPTION
### Issues fixed:
- Progress and submission state were not synced across tabs
- Timer and submission status were resetting inconsistently
- Saved progress was not preserved correctly on reload in other tabs

### Changes made:
- Extended cross-tab sync payload to include:
  - submittedAnswers
  - isSubmitted
  - secondsLeft
  - currentQuestionIndex
- Updated storage listener to restore full quiz state across tabs
- Ensured retry action resets state consistently across all tabs
- Maintained synchronization between UI and internal state

### Result:
- All tabs now stay fully in sync
- Progress, score, and submission state remain consistent
- Refresh does not break progress
- Retry works cleanly across multiple tabs