### PR TITLE
Fix wishlist persistence by saving to localStorage

### DIFF
--- a/src/components/shop-house/hooks/useDebugQuestShop.js
+++ b/src/components/shop-house/hooks/useDebugQuestShop.js
@@ -12,7 +12,13 @@ export function useDebugQuestShop() {
   const [activeCategory, setActiveCategory] = useState('')
   const [sortDirection, setSortDirection] = useState('asc')
   const [page, setPage] = useState(1)
-  const [wishlist, setWishlist] = useState([])
+  const [wishlist, setWishlist] = useState(() => {
+    try {
+      return JSON.parse(localStorage.getItem('shop_wishlist')) || []
+    } catch {
+      return []
+    }
+  })
   const [cart, setCart] = useState(() => {
     try {
       return JSON.parse(localStorage.getItem('shop_cart')) || []
@@ -102,6 +108,10 @@ export function useDebugQuestShop() {
   useEffect(() => {
     localStorage.setItem('shop_cart', JSON.stringify(cart))
   }, [cart])
+
+  useEffect(() => {
+    localStorage.setItem('shop_wishlist', JSON.stringify(wishlist))
+  }, [wishlist])
 
   const wishlistSet = new Set(wishlist)
 


### PR DESCRIPTION
### Issue #80 Fixed

Shop House — Wishlist Not Persisted


### What was fixed

The wishlist was not being saved to [localStorage], causing it to reset on page refresh. Users lost their wishlist selections when navigating away or refreshing the page.


### Root cause

In [useDebugQuestShop.js], the [wishlist] state was managed in memory without being persisted to [localStorage], unlike the [cart] state.

### Approach / Solution

Implemented persistence for the wishlist by saving it to [localStorage] and loading it on initialization:

1. Added [useEffect] to load the wishlist from [localStorage] on component mount.
2. Added [useEffect] to save the wishlist to [localStorage] whenever it changes.
3. No other behavior touched (cart, coupon, checkout, pagination, search, sort untouched).
4. No new dependencies.


### Files changed
[useDebugQuestShop.js]


### Testing
Add items to the wishlist → Refresh the page → Wishlist items remain intact.