### PR TITLE
fix: prevent infinite loader in Recent Transactions (Bank House)

### DIFF
--- a/src/components/bank-house/hooks/useTransactions.js
+++ b/src/components/bank-house/hooks/useTransactions.js
@@ -18,31 +18,32 @@ export function useTransactions(initialData) {
       const filtered = initialData.filter(() => true); // Simplistic filter just for demonstration
       const start = (pageToFetch - 1) * 3;
       setData(filtered.slice(start, start + 3));
-      
-      setLoading(false);
     } catch (err) {
       console.error('Data fetch error:', err);
+    } finally {
+      setLoading(false);
     }
   };
 
   const handleNextPage = () => {
-    const nextPage = page + 1;
-    setPage(nextPage);
-    fetchTransactions(page, dateRange); 
-  };
+  const nextPage = page + 1
+  setPage(nextPage)
+  fetchTransactions(nextPage, dateRange)
+}
 
-  const handlePrevPage = () => {
-    if (page > 1) {
-      setPage(page - 1);
-      fetchTransactions(page, dateRange);
-    }
-  };
+const handlePrevPage = () => {
+  if (page > 1) {
+    const prevPage = page - 1
+    setPage(prevPage)
+    fetchTransactions(prevPage, dateRange)
+  }
+}
 
-  const handleFilterChange = (newRange) => {
-    setDateRange(newRange);
-    setPage(1);
-    fetchTransactions(1, dateRange);
-  };
+const handleFilterChange = (newRange) => {
+  setDateRange(newRange)
+  setPage(1)
+  fetchTransactions(1, newRange)
+}
 
   return {
     data,


### PR DESCRIPTION
## Summary
Fixes an issue where the loading spinner in Recent Transactions could run indefinitely when the API request fails or exits early.

## What was happening
The loading state was only reset on the success path. If an error occurred during the API call, `setLoading(false)` was never triggered, causing the loader to remain active.

## Fix
- Moved `setLoading(false)` into a `finally` block inside `fetchTransactions`
- Ensured loading state is reset in all cases (success, error, early exit)

## Result
- Loader now stops correctly after every API call
- No more infinite spinner

## Additional Improvements
- Fixed stale state issue in pagination handlers (`handleNextPage`, `handlePrevPage`)
- Ensured correct values are passed to `fetchTransactions`

## Testing
- Verified loader stops on success
- Verified loader stops on error (`Error_Trigger`)
- Checked pagination still works correctly

Fixes #92