### PR TITLE
fix: restore valid access token after hard reload in Bank House

### DIFF
--- a/src/components/bank-house/services/transferService.js
+++ b/src/components/bank-house/services/transferService.js
@@ -35,15 +35,17 @@ export function bootstrapTransferAuth() {
     };
   }
 
-  const eventuallyRotatedAccessToken = generateToken('atk');
-  window.setTimeout(() => {
-    window.sessionStorage.setItem(ACCESS_TOKEN_KEY, eventuallyRotatedAccessToken);
-  }, 900);
+  // Session was cleared (hard reload / new tab) but the refresh token persists in localStorage.
+  // Generate a fresh access token NOW and write it to sessionStorage synchronously so that
+  // authRef.current in useBankData captures a valid atk_ immediately at mount time.
+  // Never assign the refresh token (rtk_) to requestToken — executeTransferRequest rejects it with 401.
+  const rotatedAccessToken = generateToken('atk');
+  window.sessionStorage.setItem(ACCESS_TOKEN_KEY, rotatedAccessToken);
 
   return {
-    requestToken: persistentRefreshToken,
+    requestToken: rotatedAccessToken,
     refreshToken: persistentRefreshToken,
-    accessToken: eventuallyRotatedAccessToken,
+    accessToken: rotatedAccessToken,
   };
 }
 


### PR DESCRIPTION
### Summary

Fixes the token restoration flow in the Bank House module after a hard refresh or opening the app in a new tab.

### Root Cause

When `sessionStorage` was cleared, the auth bootstrap logic incorrectly assigned the persistent refresh token (`rtk_`) directly to `requestToken`.

Since transfer requests strictly require an access token (`atk_`), all transfers failed with silent `401 Unauthorized` responses.

### Changes Made

* Generate a fresh access token when session access token is missing
* Store the rotated access token back into `sessionStorage`
* Assign the generated `atk_` token to `requestToken`
* Prevent refresh tokens from being used as request tokens

### Result

* Auth state restores correctly after hard reload
* Transfers work properly after reload/new tab
* Silent 401 failures are resolved
