### PR TITLE
Sampurnasit/search beneficiary fixed#91

### DIFF
--- a/src/components/bank-house/BeneficiariesPanel.jsx
+++ b/src/components/bank-house/BeneficiariesPanel.jsx
@@ -12,14 +12,8 @@ export default function BeneficiariesPanel({ beneficiaries, onSelectBeneficiary 
       return;
     }
 
-    // Bug 6: Use cached matching array from first search, ignoring subsquent searches
-    if (cachedSearch.current) {
-      setFiltered(cachedSearch.current);
-    } else {
-      const res = beneficiaries.filter(b => b.name.toLowerCase().includes(search.toLowerCase()));
-      cachedSearch.current = res; 
-      setFiltered(res);
-    }
+    const res = beneficiaries.filter(b => b.name.toLowerCase().includes(search.toLowerCase()));
+    setFiltered(res);
   }, [search, beneficiaries]);
 
   return (

--- a/src/components/bank-house/BeneficiariesPanel.jsx
+++ b/src/components/bank-house/BeneficiariesPanel.jsx
@@ -44,7 +44,7 @@ export default function BeneficiariesPanel({ beneficiaries, onSelectBeneficiary 
             {/* Bug 5: Changing beneficiary maps wrong index/id */}
             {/* Mapping over filtered array, but index refers to original array */}
             <button 
-              onClick={() => onSelectBeneficiary(ben)}
+              onClick={() => onSelectBeneficiary(beneficiaries[index])}
               style={{ background: 'transparent', border: 'none', color: 'var(--bank-primary)', cursor: 'pointer', padding: '4px' }}
             >
               <ArrowUpRight size={16}/>

--- a/src/components/bank-house/BeneficiariesPanel.jsx
+++ b/src/components/bank-house/BeneficiariesPanel.jsx
@@ -44,7 +44,7 @@ export default function BeneficiariesPanel({ beneficiaries, onSelectBeneficiary 
             {/* Bug 5: Changing beneficiary maps wrong index/id */}
             {/* Mapping over filtered array, but index refers to original array */}
             <button 
-              onClick={() => onSelectBeneficiary(beneficiaries[index])}
+              onClick={() => onSelectBeneficiary(ben)}
               style={{ background: 'transparent', border: 'none', color: 'var(--bank-primary)', cursor: 'pointer', padding: '4px' }}
             >
               <ArrowUpRight size={16}/>

--- a/src/components/bank-house/hooks/useTransactions.js
+++ b/src/components/bank-house/hooks/useTransactions.js
@@ -26,24 +26,24 @@ export function useTransactions(initialData) {
   };
 
   const handleNextPage = () => {
-    const nextPage = page + 1;
-    setPage(nextPage);
-    fetchTransactions(nextPage, dateRange); 
-  };
+  const nextPage = page + 1
+  setPage(nextPage)
+  fetchTransactions(nextPage, dateRange)
+}
 
-  const handlePrevPage = () => {
-    if (page > 1) {
-      const prevPage = page - 1;
-      setPage(prevPage);
-      fetchTransactions(prevPage, dateRange);
-    }
-  };
+const handlePrevPage = () => {
+  if (page > 1) {
+    const prevPage = page - 1
+    setPage(prevPage)
+    fetchTransactions(prevPage, dateRange)
+  }
+}
 
-  const handleFilterChange = (newRange) => {
-    setDateRange(newRange);
-    setPage(1);
-    fetchTransactions(1, newRange);
-  };
+const handleFilterChange = (newRange) => {
+  setDateRange(newRange)
+  setPage(1)
+  fetchTransactions(1, newRange)
+}
 
   return {
     data,

--- a/src/components/bank-house/hooks/useTransactions.js
+++ b/src/components/bank-house/hooks/useTransactions.js
@@ -28,20 +28,21 @@ export function useTransactions(initialData) {
   const handleNextPage = () => {
     const nextPage = page + 1;
     setPage(nextPage);
-    fetchTransactions(page, dateRange); 
+    fetchTransactions(nextPage, dateRange); 
   };
 
   const handlePrevPage = () => {
     if (page > 1) {
-      setPage(page - 1);
-      fetchTransactions(page, dateRange);
+      const prevPage = page - 1;
+      setPage(prevPage);
+      fetchTransactions(prevPage, dateRange);
     }
   };
 
   const handleFilterChange = (newRange) => {
     setDateRange(newRange);
     setPage(1);
-    fetchTransactions(1, dateRange);
+    fetchTransactions(1, newRange);
   };
 
   return {


### PR DESCRIPTION
Fix: Search functionality lock in Beneficiaries Panel
Closes #91 

Bug found
In the Bank House, the "Quick Beneficiaries" search box would stop updating results after the first query. Typing additional characters or clearing the search would not change the displayed list.

Root cause
In BeneficiariesPanel.jsx, a useRef hook (cachedSearch.current) was being used to store the results of the first search query. The code was logic-locked to return this cached value for every subsequent render, ignoring any changes to the search input.

Fix applied
Removed the cachedSearch reference and the conditional check that was locking the results.
The component now correctly filters the beneficiaries list on every render based on the current search state.
Synchronized useTransactions.js with the main branch to resolve merge conflicts.

Testing done
[x] Reproduced the search lock bug before applying fix [x] Confirmed the search box now updates dynamically on every keystroke [x] Verified the branch is mergeable with main [x] Tested on: Chrome (Windows 11)

<img width="1742" height="860" alt="image" src="https://github.com/user-attachments/assets/6dca3bfc-af5a-4c5b-b8db-3bf9ba90a9d8" />
