### PR TITLE
Fix arcade coin farming: prevent coins from accumulating without acti…

### DIFF
--- a/src/components/ArcadeHouse.jsx
+++ b/src/components/ArcadeHouse.jsx
@@ -123,7 +123,7 @@ export default function ArcadeHouse({ onBack }) {
   }, [coins])
 
   useEffect(() => {
-    if (isPaused) {
+    if (isPaused || !gameStarted) {
       return
     }
 
@@ -140,7 +140,7 @@ export default function ArcadeHouse({ onBack }) {
     }, 900)
 
     return () => clearInterval(ticker)
-  }, [isPaused])
+  }, [isPaused, gameStarted])
 
   useEffect(() => {
     const keyboardHandler = (event) => {


### PR DESCRIPTION
### Issue #126  Fixed
**Arcade House — Continuous Coin Farming Without Active Game**

### What was fixed
Coins were continuously earned without playing any games. The coin counter increased steadily every 900ms even when the user was idle in the lobby or hadn't started a game session, allowing passive coin accumulation.

### Root cause
In ArcadeHouse.jsx, the ticker useEffect hook only checked isPaused but ignored the gameStarted state. The dependency array also lacked gameStarted, preventing proper cleanup when game state changed. This allowed the interval to run continuously in the lobby, adding +2 coins every 900ms regardless of actual gameplay.

### Approach / Solution
Added gameStarted to both the early-return guard and the dependency array so the ticker only runs during active gameplay:

- Added condition: if (isPaused || !gameStarted) return undefined
- Updated dependency array: [isPaused, gameStarted]
- No other behavior touched (health, XP, score calculation during games untouched).
- No new dependencies.**

### Files changed
[ArcadeHouse.jsx]

### Testing
Open Arcade House → Stay in Game Lobby for 30+ seconds → Coins should NOT increase. Start a game → Coins now increase correctly during active gameplay.