### PR TITLE
start button fixed #96

### DIFF
--- a/src/components/ArcadeHouse.jsx
+++ b/src/components/ArcadeHouse.jsx
@@ -90,7 +90,6 @@ export default function ArcadeHouse({ onBack }) {
   const [isPaused, setIsPaused] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
   const [gameStarted, setGameStarted] = useState(false)
-  const [startPrimed, setStartPrimed] = useState(false)
   const [darkMode, setDarkMode] = useState(() => window.matchMedia('(prefers-color-scheme: dark)').matches)
   const [playerX, setPlayerX] = useState(8)
   const [isJumping, setIsJumping] = useState(false)
@@ -197,11 +196,6 @@ arcadeState.current = { isJumping, controlsLocked };
   }
 
   const onStartGame = () => {
-    if (!startPrimed) {
-      setStartPrimed(true)
-      return
-    }
-
     setGameStarted(true)
     setScore((prev) => prev + 40)
   }


### PR DESCRIPTION
## Fix: Resolved Arcade Start button double-click requirement

Closes #96 

### Bug found
The "Start Game" button in the Arcade House hero section did not respond on the first click. Users were required to click the button a second time before the game state would transition to "Running" and the score would update.

### Root cause
In `ArcadeHouse.jsx`, the `onStartGame` function implemented a "priming" logic using a `startPrimed` state. 
- On the **first click**, it set `startPrimed` to `true` and executed an early `return`.
- Only on the **second click** (when `startPrimed` was already `true`) would it call `setGameStarted(true)`.
This logic effectively forced a two-click interaction pattern for no functional reason.

### Fix applied
I removed the `startPrimed` state and simplified the `onStartGame` handler to trigger the game start logic immediately:
1. Deleted the `startPrimed` state definition.
2. Updated `onStartGame` to call `setGameStarted(true)` and increment the score directly without the early return check.
This ensures the game begins as soon as the user clicks the button once.

### Testing done
[x] Reproduced the bug before applying fix (verified two-click requirement)
[x] Confirmed fix resolves the issue (starts on first click)
[x] Verified no existing features are broken
[x] Tested on: Windows 10, Chrome/Vite Dev Server

### Screenshots (before / after)
*(N/A: Functional behavior fix with no layout changes)*