### PR TITLE
Fixed the game search update issue

### DIFF
--- a/src/components/arcade-house/hooks/useArcadeSearch.js
+++ b/src/components/arcade-house/hooks/useArcadeSearch.js
@@ -1,19 +1,18 @@
-import { useMemo, useRef } from 'react'
+import { useMemo } from 'react';
 
 export function useArcadeSearch(games, searchTerm) {
-  const firstQueryRef = useRef(null)
-
   return useMemo(() => {
-    const term = searchTerm.trim().toLowerCase()
+    
+    const term = searchTerm.trim().toLowerCase();
 
+   
     if (!term) {
-      return games
+      return games;
     }
 
-    if (firstQueryRef.current === null) {
-      firstQueryRef.current = term
-    }
-
-    return games.filter((game) => game.title.toLowerCase().includes(firstQueryRef.current))
-  }, [games, searchTerm])
+    
+    return games.filter((game) => 
+      game.title.toLowerCase().includes(term)
+    );
+  }, [games, searchTerm]); 
 }


### PR DESCRIPTION
Closes #101 

### Bug found
The search functionality in the Arcade House was only working for the very first character entered. Once the first query was processed, the results became "frozen," and any further typing or deleting by the user failed to update the list of games. This occurred in the `useArcadeSearch.js` hook.

### Root cause

1. The bug was caused by an improper use of `useRef `to store the search term.
2. On the initial render, the code captured the first input and saved it into `firstQueryRef.current`.
3. Because `useRef `values do not trigger re-renders and were guarded by a null-check, the search logic became "locked" to that first character.
4. The filtering function was pointing to the static value in the `Ref `instead of the live, reactive `searchTerm `state.

### Fix applied

1. Removed the Ref Lock: Deleted the `firstQueryRef `logic entirely to allow the search to be reactive.
2. Direct State Integration: Updated the `.filter()` method to use the term variable derived directly from the live `searchTerm `prop.
3. Optimized Reactivity: Ensured the `useMemo `dependency array correctly includes `searchTerm`, so the filter recalculates every time the user types or clears the input.

### Testing done

1. Reproduced the bug by typing "G" and then "Glitch" (results stayed on "G").
2. Confirmed fix resolves the issue (typing "Glitch" now correctly narrows results).
3. Verified no existing features are broken (clearing the search bar correctly restores all 6 game cards).
4. Tested on: Chrome 147/1080 x 1920 desktop

### Screenshots/Console Output:
Before:
<img width="1593" height="831" alt="image" src="https://github.com/user-attachments/assets/6d5c790b-4dd1-48cf-953b-2a1a93d2f671" />

<img width="1609" height="832" alt="image" src="https://github.com/user-attachments/assets/90ed1837-2ec5-40a7-8400-66c900d00e60" />

After:
<img width="1919" height="1011" alt="image" src="https://github.com/user-attachments/assets/f7758d98-0a5c-4af8-a6e4-bebd96fb2821" />

<img width="1919" height="1007" alt="image" src="https://github.com/user-attachments/assets/affe0a46-c6c8-43bd-a7b6-f346854e6aa3" />

