### PR TITLE
Fix duplicate leaderboard entries and stabilize score submision

### DIFF
--- a/src/components/arcade-house/hooks/useArcadeRealtime.js
+++ b/src/components/arcade-house/hooks/useArcadeRealtime.js
@@ -33,10 +33,7 @@ export function useArcadeRealtime(score) {
     }
 
     submitScore('You', score)
-    if (reconnectCount > 0) {
-      submitScore('You', score)
-    }
-  }, [isConnected, reconnectCount, score])
+  }, [isConnected, score])
 
   const connectedPlayers = useMemo(() => players, [players])
 

--- a/src/components/arcade-house/services/leaderboardService.js
+++ b/src/components/arcade-house/services/leaderboardService.js
@@ -17,7 +17,7 @@ export function fetchLeaderboardSnapshot(playerScore) {
     setTimeout(() => {
       const rows = [
         ...basePlayers.map((item) => ({ ...item, score: jitter(item.score, 300) })),
-        { id: 'you', name: 'You', score: playerScore },
+       
       ]
 
       submissions.slice(-3).forEach((entry, index) => {
@@ -31,5 +31,8 @@ export function fetchLeaderboardSnapshot(playerScore) {
 }
 
 export function submitScore(name, score) {
-  submissions.push({ name, score, at: Date.now() })
+  submissions = submissions.filter((entry) => entry.name !==name)
+ submissions.push({
+  name, score, at: Date.now(),
+ })
 }


### PR DESCRIPTION
## Bug
Arcade House leaderboard showed duplicate player entries after reconnecting or repeated score submissions.

## Root Cause
There were multiple causes behind the duplicate leaderboard behavior:

1. submitScore() could run multiple times during reconnect flow
2. The leaderboard accepted repeated submissions for the same player
3. Leaderboard rows were generated without preventing duplicate player entries

## Fix
- Removed duplicate score submission flow during reconnect
- Stabilized score submission behavior
- Added filtering before pushing new leaderboard submissions
- Prevented repeated player entries from appearing in leaderboard snapshots

## Result
- Leaderboard now shows a single entry per player
- Reconnect no longer creates duplicate rows
- Score updates behave consistently
- Realtime leaderboard UI is more stable