### PR TITLE
Fixed sound button display issue

### DIFF
--- a/src/components/ArcadeHouse.jsx
+++ b/src/components/ArcadeHouse.jsx
@@ -400,7 +400,7 @@ arcadeState.current = { isJumping, controlsLocked };
                     <Pause size={14} /> {isPaused ? 'Resume' : 'Pause'}
                   </button>
                   <button type="button" className="btn-ghost" onClick={() => setSoundOn((prev) => !prev)}>
-                    {soundOn ? <VolumeX size={14} /> : <Volume2 size={14} />} {soundOn ? 'Sound On' : 'Muted'}
+                    {soundOn ? <Volume2 size={14} /> : <VolumeX size={14} />} {soundOn ? 'Sound On' : 'Muted'}
                   </button>
                 </div>
               </article>


### PR DESCRIPTION
Closes #97 

### Bug found
The sound toggle icon in the Arcade House building displayed the opposite visual state of the actual audio setting. When the sound was enabled, the UI showed a "Muted" icon, and when the sound was disabled, it showed an "Active Volume" icon. This mismatch occurred in the live-panel action header.

### Root cause

1. The bug was a logical inversion within the JSX ternary operator in `ArcadeHouse.jsx`.
2. The code was explicitly rendering the `<VolumeX />` (mute) component when the `soundOn `state variable was `true`.
3. Consequently, the `<Volume2 />` (active) component was only rendered when the state was `false`.

### Fix applied

1. Logic Correction: Swapped the positions of the `<Volume2 />` and `<VolumeX />` components within the ternary operator.
2. State Alignment: Ensured that the visual icon now correctly corresponds with the `soundOn ? 'Sound On' : 'Muted'` text label.
3. Consistency: Validated that the `onClick `handler correctly toggles the boolean state, which now reflects accurately through the corrected icon mapping.

### Testing done

- Reproduced the bug before applying fix (saw Mute icon while hearing sound).
- Confirmed fix resolves the issue (icon and text now move in sync).
- Verified no existing features are broken (Pause/Resume button logic remains intact).
- Tested on: Chrome 147/1920 x 1080 desktop

### Screenshots/Console Output:

Before:
<img width="1601" height="819" alt="image" src="https://github.com/user-attachments/assets/b9ec66eb-92b9-4885-b0c5-8db11a376c28" />

<img width="1594" height="820" alt="image" src="https://github.com/user-attachments/assets/c7395525-5ee6-4c50-933d-41ed0e1eb04c" />

After:
<img width="1919" height="1010" alt="image" src="https://github.com/user-attachments/assets/a608056f-af81-4581-9c01-b3e67096b382" />

<img width="1919" height="1008" alt="image" src="https://github.com/user-attachments/assets/8f484e32-df09-4315-9b02-f6933a9f32d3" />

