### PR TITLE
high score label fixed of the arcade house

### DIFF
--- a/src/components/ArcadeHouse.jsx
+++ b/src/components/ArcadeHouse.jsx
@@ -100,7 +100,6 @@ export default function ArcadeHouse({ onBack }) {
   const [xp, setXp] = useState(68)
   
   const [streak, setStreak] = useState(5)
-  const highScoreLabel = 'High Score: 8,480'
   const rapidJumpRef = useRef([])
   const jumpLock = useRef(false); // Our physical lock
 const arcadeState = useRef({ isJumping, controlsLocked });
@@ -111,6 +110,14 @@ arcadeState.current = { isJumping, controlsLocked };
 
   const filteredCards = useArcadeSearch(gameCards, search)
   const { leaderboard, players, isConnected, reconnectCount, leaveArena, reconnectArena } = useArcadeRealtime(score)
+
+  const highScore = useMemo(() => {
+    if (leaderboard && leaderboard.length > 0) {
+      return leaderboard[0].score
+    }
+    return 11940
+  }, [leaderboard])
+  const highScoreLabel = `High Score: ${highScore.toLocaleString()}`
 
   useEffect(() => {
     const spinnerTimer = setTimeout(() => {


### PR DESCRIPTION
## Fix: Dynamic High Score Label in Arcade House

Closes issue #98 

### Bug found
The High Score label in the Arcade House module was displaying an incorrect and misleading value of **8,480**. This value was static and did not change, even though the live leaderboard right next to it showed players with scores exceeding **11,000**.

### Root cause
In `src/components/ArcadeHouse.jsx`, the variable `highScoreLabel` was defined as a hardcoded string:
```javascript
const highScoreLabel = 'High Score: 8,480'
```
This variable was never updated, making it completely disconnected from the actual game state or the leaderboard data fetched by the `useArcadeRealtime` hook.

### Fix applied
Implemented a dynamic calculation for the high score using the `useMemo` hook:
1.  **Dynamic Derivation**: The high score is now derived directly from the `leaderboard` array provided by `useArcadeRealtime`.
2.  **Consistency**: Since the leaderboard is already sorted in descending order, the fix simply takes the score of the first entry (`leaderboard[0].score`).
3.  **Fallback Logic**: If the leaderboard has not yet loaded, it defaults to **11,940**, which matches the top score in the application's fallback leaderboard data.
4.  **Formatting**: Added `toLocaleString()` to ensure the score is formatted with thousands separators, maintaining the premium look of the UI.
5.  **Initialization Order**: Moved the high score calculation after the `useArcadeRealtime` call to prevent initialization errors.

### Testing done
[x] Reproduced the bug before applying fix (verified static string in code)
[x] Confirmed fix resolves the issue (high score now matches the top leaderboard entry)
[x] Verified no existing features are broken (leaderboard and score tracking still function normally)
[x] Tested on: Windows / Chrome (Standard Desktop Viewport)

### Screenshots (before / after)
*UI updated from a static "High Score: 8,480" to a dynamic "High Score: 11,940" (or higher based on live data).*

<img width="1852" height="882" alt="image" src="https://github.com/user-attachments/assets/954bde9c-25e4-43f7-9fb0-a1a7a3961521" />
