### PR TITLE
the player avatar now is removed directly from the multiplayer arena tab #102

### DIFF
--- a/src/components/ArcadeHouse.jsx
+++ b/src/components/ArcadeHouse.jsx
@@ -382,10 +382,12 @@ arcadeState.current = { isJumping, controlsLocked };
                 <div className="game-screen" role="img" aria-label="Mini platformer area">
                   <div className="scanlines" />
                   <div className="platform" />
-                  <div
-                    className="player-sprite"
-                    style={{ left: `${playerX}%`, bottom: `${16 + jumpOffset}px` }}
-                  />
+                  {isConnected && (
+                    <div
+                      className="player-sprite"
+                      style={{ left: `${playerX}%`, bottom: `${16 + jumpOffset}px` }}
+                    />
+                  )}
                   <div className="enemy enemy-a" />
                   <div className="enemy enemy-b" />
                 </div>

--- a/src/components/arcade-house/services/multiplayerService.js
+++ b/src/components/arcade-house/services/multiplayerService.js
@@ -9,9 +9,7 @@ export function getRoomPlayers() {
 }
 
 export function leaveRoom(playerId) {
-  roomPlayers = roomPlayers.map((player) =>
-    player.id === playerId ? { ...player, connected: false } : player,
-  )
+  roomPlayers = roomPlayers.filter((player) => player.id !== playerId)
   return roomPlayers
 }
 


### PR DESCRIPTION
## Fix: Resolved Persistent Player Avatar and Arena Entry After Leaving

Closes #102 

### Bug found
The player's avatar remained visible in the Arcade House mini-game screen even after selecting "Leave" in the Multiplayer Arena tab. Additionally, the player's name persisted in the "Arena Session" list as a greyed-out (ghost) entry instead of being completely removed.

### Root cause
There were two primary causes:
1. **Unconditional Rendering**: In `ArcadeHouse.jsx`, the `.player-sprite` element was rendered without checking the connection status, meaning it stayed on screen regardless of the arena state.
2. **State Retention**: In `src/components/arcade-house/services/multiplayerService.js`, the `leaveRoom()` function used `.map()` to set a `connected: false` flag. The UI was designed to render these "disconnected" players with a `.ghost` class rather than omitting them entirely from the active session.

### Fix applied
1. **Conditional Avatar Display**: Wrapped the `player-sprite` div in `ArcadeHouse.jsx` with a check for the `isConnected` boolean. This ensures the character sprite is unmounted when the player leaves the session.
2. **List Filtering**: Updated the `leaveRoom()` function in `multiplayerService.js` to use `.filter()` instead of `.map()`. This completely removes the player's record from the `roomPlayers` array, allowing the UI to re-render with only active participants.
3. **Recovery Logic**: Verified that `reconnectRoom()` correctly handles adding the player back into the array if they choose to rejoin.

### Testing done
- [x] Reproduced the bug before applying fix: Avatar remained on platform after clicking "Leave".
- [x] Confirmed fix resolves the issue: Avatar disappears and "You" entry is removed from the list.
- [x] Verified no existing features are broken: Jumping and movement still work correctly while connected; reconnecting restores all functionality.
- [x] Tested on: Chrome (Desktop), Responsive view (Mobile/Tablet).

### Screenshots (before / after)
*Before: Avatar stuck on platform and "You (left)" visible in sidebar.*

<img width="1877" height="887" alt="image" src="https://github.com/user-attachments/assets/d3ea37c3-7fb1-4bac-a50f-f86543745c08" />

*After: Platform is empty and "You" entry is removed from the Arena Session list upon leaving.*

<img width="1847" height="877" alt="image" src="https://github.com/user-attachments/assets/5e4ded5f-ba6e-41da-9540-7613ac43c786" />
