### PR TITLE
Fixed the cabinets not opening interactive session issue

### DIFF
--- a/src/components/ArcadeHouse.jsx
+++ b/src/components/ArcadeHouse.jsx
@@ -1,9 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { readSavedCoins, saveCoins } from './arcade-house/services/coinStorageService';
+
+import { readSavedCoins, saveCoins } from './arcade-house/services/coinStorageService'
+
 import {
   ChevronLeft,
   Search,
-  Settings,
   Pause,
   Volume2,
   VolumeX,
@@ -17,7 +18,9 @@ import {
   Sun,
   Moon,
 } from 'lucide-react'
+
 import './ArcadeHouse.css'
+
 import { initializeArcadeAssets } from './arcade-house/services/assetLoaderService'
 import { useArcadeSearch } from './arcade-house/hooks/useArcadeSearch'
 import { useArcadeRealtime } from './arcade-house/hooks/useArcadeRealtime'
@@ -60,16 +63,22 @@ function getMachineIcon(gameId) {
   switch (gameId) {
     case 'neon-runner':
       return <Flame size={24} />
+
     case 'byte-blaster':
       return <Trophy size={24} />
+
     case 'glitch-racer':
       return <Play size={24} />
+
     case 'vector-jump':
       return <Heart size={24} />
+
     case 'kernel-kombat':
       return <Gamepad2 size={24} />
+
     case 'stack-smash':
       return <Coins size={24} />
+
     default:
       return <Play size={24} />
   }
@@ -83,40 +92,59 @@ export default function ArcadeHouse({ onBack }) {
   const [activeTab, setActiveTab] = useState('Game Lobby')
   const [search, setSearch] = useState('')
   const [coins, setCoins] = useState(() => readSavedCoins(12490))
-  useEffect(() => {
-    saveCoins(coins);
-  }, [coins]);
+
   const [soundOn, setSoundOn] = useState(true)
   const [isPaused, setIsPaused] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
   const [gameStarted, setGameStarted] = useState(false)
-  const [darkMode, setDarkMode] = useState(() => window.matchMedia('(prefers-color-scheme: dark)').matches)
+
+  const [activeGame, setActiveGame] = useState(null)
+
+  const [darkMode, setDarkMode] = useState(() =>
+    window.matchMedia('(prefers-color-scheme: dark)').matches
+  )
+
   const [playerX, setPlayerX] = useState(8)
   const [isJumping, setIsJumping] = useState(false)
   const [jumpTick, setJumpTick] = useState(0)
-  const [controlsLocked, setControlsLocked] = useState(false)
+  const [controlsLocked] = useState(false)
+
   const [score, setScore] = useState(3180)
   const [health, setHealth] = useState(82)
   const [xp, setXp] = useState(68)
-  
   const [streak, setStreak] = useState(5)
-  const rapidJumpRef = useRef([])
-  const jumpLock = useRef(false); // Our physical lock
-const arcadeState = useRef({ isJumping, controlsLocked });
-arcadeState.current = { isJumping, controlsLocked };
 
-  
+  const jumpLock = useRef(false)
 
+  const arcadeState = useRef({
+    isJumping,
+    controlsLocked,
+  })
+
+  arcadeState.current = {
+    isJumping,
+    controlsLocked,
+  }
 
   const filteredCards = useArcadeSearch(gameCards, search)
-  const { leaderboard, players, isConnected, reconnectCount, leaveArena, reconnectArena } = useArcadeRealtime(score)
+
+  const {
+    leaderboard,
+    players,
+    isConnected,
+    reconnectCount,
+    leaveArena,
+    reconnectArena,
+  } = useArcadeRealtime(score)
 
   const highScore = useMemo(() => {
     if (leaderboard && leaderboard.length > 0) {
       return leaderboard[0].score
     }
+
     return 11940
   }, [leaderboard])
+
   const highScoreLabel = `High Score: ${highScore.toLocaleString()}`
 
   useEffect(() => {
@@ -155,73 +183,90 @@ arcadeState.current = { isJumping, controlsLocked };
     return () => clearInterval(ticker)
   }, [isPaused, gameStarted])
 
-  
   useEffect(() => {
-  const handleKeyDown = (e) => {
-    if (arcadeState.current.controlsLocked) return;
+    const handleKeyDown = (e) => {
+      if (arcadeState.current.controlsLocked) return
 
-    // Movement
-    if (e.key === 'a' || e.key === 'ArrowLeft') setPlayerX(p => Math.max(0, p - 4));
-    if (e.key === 'd' || e.key === 'ArrowRight') setPlayerX(p => Math.min(88, p + 4));
+      if (e.key === 'a' || e.key === 'ArrowLeft') {
+        setPlayerX((p) => Math.max(0, p - 4))
+      }
 
-    // Jump - Point directly to our locked function
-    if (e.key === ' ' || e.key === 'w' || e.key === 'ArrowUp') {
-      e.preventDefault();
-      onJump(); 
+      if (e.key === 'd' || e.key === 'ArrowRight') {
+        setPlayerX((p) => Math.min(88, p + 4))
+      }
+
+      if (e.key === ' ' || e.key === 'w' || e.key === 'ArrowUp') {
+        e.preventDefault()
+        onJump()
+      }
     }
-  };
 
-  window.addEventListener('keydown', handleKeyDown);
-  return () => window.removeEventListener('keydown', handleKeyDown);
-}, []); // Empty array = listener never dies, never lags
+    window.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [])
 
   useEffect(() => {
-  if (!isJumping || jumpTick <= 0) {
-    if (isJumping) {
-      setIsJumping(false);
-      // This is the ONLY place the lock is released
-      setTimeout(() => { jumpLock.current = false; }, 10); 
+    if (!isJumping || jumpTick <= 0) {
+      if (isJumping) {
+        setIsJumping(false)
+
+        setTimeout(() => {
+          jumpLock.current = false
+        }, 10)
+      }
+
+      return
     }
-    return;
-  }
 
-  const timer = setTimeout(() => setJumpTick(t => t - 1), 50);
-  return () => clearTimeout(timer);
-}, [isJumping, jumpTick]);
+    const timer = setTimeout(() => {
+      setJumpTick((t) => t - 1)
+    }, 50)
 
-  const jumpOffset = isJumping ? Math.max(0, Math.sin((jumpTick / 6) * Math.PI) * 56) : 0
+    return () => clearTimeout(timer)
+  }, [isJumping, jumpTick])
 
-  const playCard = (reward) => {
-    setIsJumping(false);
-  setJumpTick(0);
-    setCoins((prev) => prev + reward)
-    setScore((prev) => prev + reward)
+  const jumpOffset = isJumping
+    ? Math.max(0, Math.sin((jumpTick / 6) * Math.PI) * 56)
+    : 0
+
+  const playCard = (card) => {
+    setIsJumping(false)
+    setJumpTick(0)
+
+    setCoins((prev) => prev + card.reward)
+    setScore((prev) => prev + card.reward)
     setXp((prev) => clamp(prev + 4, 0, 100))
+
     if (Math.random() > 0.7) {
       setStreak((prev) => prev + 1)
     }
+
+    setGameStarted(true)
+    setActiveGame(card)
+    setActiveTab('Mini Games')
   }
 
   const onStartGame = () => {
     setGameStarted(true)
+
     setScore((prev) => prev + 40)
+
+    setXp((prev) => Math.min(prev + 4, 100))
   }
 
   const onJump = () => {
-  // 1. Check the physical lock immediately
-  // We use the arcadeState ref to see if controls are locked globally
-  if (jumpLock.current || arcadeState.current.controlsLocked) return;
+    if (jumpLock.current || arcadeState.current.controlsLocked) return
 
-  // 2. Lock the gate synchronously
-  // This happens in nanoseconds, blocking any other clicks that arrive 
-  // before the next render.
-  jumpLock.current = true; 
+    jumpLock.current = true
 
-  // 3. Trigger the physics and state updates
-  setIsJumping(true);
-  setJumpTick(6);
-  setScore((prev) => prev + 28);
-};
+    setIsJumping(true)
+    setJumpTick(6)
+
+    setScore((prev) => prev + 28)
+  }
 
   return (
     <main className={`arcade-shell ${darkMode ? 'dark-mode' : ''}`}>
@@ -231,6 +276,7 @@ arcadeState.current = { isJumping, controlsLocked };
           <span>Booting arcade runtime...</span>
         </div>
       )}
+
       <div className="arcade-noise" aria-hidden="true" />
       <div className="arcade-bg-grid" aria-hidden="true" />
       <div className="arcade-orb arcade-orb-cyan" aria-hidden="true" />
@@ -242,10 +288,12 @@ arcadeState.current = { isJumping, controlsLocked };
             <button type="button" className="arcade-back" onClick={onBack}>
               <ChevronLeft size={18} /> City
             </button>
+
             <div className="arcade-title-wrap">
               <h1>
                 <span>🎮</span> Arcade House
               </h1>
+
               <p>Entertainment core malfunction detected...</p>
             </div>
           </div>
@@ -254,10 +302,16 @@ arcadeState.current = { isJumping, controlsLocked };
             <div className="coin-pill">
               <Coins size={16} /> {coins.toLocaleString()}
             </div>
-            <button className="icon-chip" type="button" aria-label="Profile avatar">
+
+            <button className="icon-chip" type="button">
               <span className="avatar-dot">PX</span>
             </button>
-            <button className="icon-chip" type="button" aria-label="Toggle Theme" onClick={() => setDarkMode((prev) => !prev)}>
+
+            <button
+              className="icon-chip"
+              type="button"
+              onClick={() => setDarkMode((prev) => !prev)}
+            >
               {darkMode ? <Sun size={16} /> : <Moon size={16} />}
             </button>
           </div>
@@ -268,6 +322,7 @@ arcadeState.current = { isJumping, controlsLocked };
             <div className="sidebar-header">
               <Gamepad2 size={16} /> Navigation Core
             </div>
+
             <nav className="sidebar-nav">
               {navItems.map((item) => (
                 <button
@@ -283,22 +338,121 @@ arcadeState.current = { isJumping, controlsLocked };
           </aside>
 
           <section className="arcade-main">
+            {gameStarted && activeGame && (
+              <section
+                className="glass-card"
+                style={{
+                  padding: '2rem',
+                  textAlign: 'center',
+                  marginBottom: '1rem',
+                }}
+              >
+                <h2>GAME STARTING...</h2>
+
+                <p>
+                  Now playing: <strong>{activeGame.title}</strong>
+                </p>
+
+                <div
+                  className="game-screen"
+                  role="img"
+                  aria-label="Interactive game area"
+                  style={{ marginTop: '1rem' }}
+                >
+                  <div className="scanlines" />
+
+                  <div className="platform" />
+
+                  <div
+                    className="player-sprite"
+                    style={{
+                      left: `${playerX}%`,
+                      bottom: `${16 + jumpOffset}px`,
+                    }}
+                  />
+
+                  <div className="enemy enemy-a" />
+                  <div className="enemy enemy-b" />
+                </div>
+
+                <div
+                  className="controls-row"
+                  style={{ marginTop: '1rem' }}
+                >
+                  <button
+                    type="button"
+                    onClick={() =>
+                      !controlsLocked &&
+                      setPlayerX((prev) => clamp(prev - 7, 0, 88))
+                    }
+                  >
+                    Move ◀
+                  </button>
+
+                  <button type="button" onClick={onJump}>
+                    Jump ▲
+                  </button>
+
+                  <button
+                    type="button"
+                    onClick={() =>
+                      !controlsLocked &&
+                      setPlayerX((prev) => clamp(prev + 7, 0, 88))
+                    }
+                  >
+                    Move ▶
+                  </button>
+                </div>
+
+                <button
+                  type="button"
+                  className="btn-ghost"
+                  style={{ marginTop: '1rem' }}
+                  onClick={() => {
+                    setGameStarted(false)
+                    setActiveGame(null)
+                  }}
+                >
+                  Quit to Lobby
+                </button>
+              </section>
+            )}
+
             <section className="hero-section glass-card">
               <div className="hero-content">
                 <span className="hero-kicker">Featured Rift Event</span>
+
                 <h2>Glitch Drift: Neon Collapse</h2>
-                <p>The arcade simulation is unstable. Enter now before the leaderboard desync wipes your run.</p>
+
+                <p>
+                  The arcade simulation is unstable. Enter now before the
+                  leaderboard desync wipes your run.
+                </p>
+
                 <div className="hero-actions">
-                  <button type="button" className="btn-primary" onClick={onStartGame}>
-                    <Play size={16} /> {gameStarted ? 'Running' : 'Start Game'}
+                  <button
+                    type="button"
+                    className="btn-primary"
+                    onClick={onStartGame}
+                  >
+                    <Play size={16} />
+                    {gameStarted ? 'Running' : 'Start Game'}
                   </button>
-                  <button type="button" className="btn-ghost" onClick={() => setGameStarted(true)}>Continue</button>
+
+                  <button
+                    type="button"
+                    className="btn-ghost"
+                    onClick={() => setGameStarted(true)}
+                  >
+                    Continue
+                  </button>
                 </div>
               </div>
 
               <div className="hero-search">
                 <label htmlFor="arcade-search" className="search-box">
                   <Search size={16} />
+
                   <input
                     id="arcade-search"
                     type="search"
@@ -314,8 +468,10 @@ arcadeState.current = { isJumping, controlsLocked };
               <article className="game-cards glass-card">
                 <header>
                   <h3>Virtual Arcade Hall</h3>
+
                   <span>{filteredCards.length} cabinets online</span>
                 </header>
+
                 <div className="hall-labels" aria-hidden="true">
                   <span>Racing</span>
                   <span>Shooter</span>
@@ -324,12 +480,17 @@ arcadeState.current = { isJumping, controlsLocked };
                   <span>Multiplayer</span>
                   <span>Retro</span>
                 </div>
+
                 <div className="cards-grid">
                   <div className="hall-ceiling" aria-hidden="true" />
                   <div className="hall-floor" aria-hidden="true" />
+
                   <div className="hall-particles" aria-hidden="true">
                     {Array.from({ length: 18 }, (_, idx) => (
-                      <span key={`arcade-particle-${idx}`} style={{ '--p': idx }} />
+                      <span
+                        key={`arcade-particle-${idx}`}
+                        style={{ '--p': idx }}
+                      />
                     ))}
                   </div>
 
@@ -338,26 +499,46 @@ arcadeState.current = { isJumping, controlsLocked };
                       key={card.id}
                       type="button"
                       className="arcade-machine"
-                      onClick={() => playCard(card.reward)}
+                      onClick={() => playCard(card)}
                     >
                       <div className="machine-marquee">{card.title}</div>
-                      <div className={`machine-screen ${index % 3 === 0 ? 'glitch-flicker-soft' : ''}`}>
-                        <div className="screen-thumb" aria-hidden="true">{getMachineIcon(card.id)}</div>
+
+                      <div
+                        className={`machine-screen ${
+                          index % 3 === 0 ? 'glitch-flicker-soft' : ''
+                        }`}
+                      >
+                        <div className="screen-thumb">
+                          {getMachineIcon(card.id)}
+                        </div>
+
                         <div className="screen-overlay">{card.title}</div>
                       </div>
+
                       <div className="machine-meta-row">
-                        <span className="difficulty-badge">{card.difficulty}</span>
-                        <span className="reward-coins">+{card.reward} coins</span>
+                        <span className="difficulty-badge">
+                          {card.difficulty}
+                        </span>
+
+                        <span className="reward-coins">
+                          +{card.reward} coins
+                        </span>
                       </div>
+
                       <div className="machine-bottom">
-                        <span className={`machine-sticker ${index % 2 === 0 ? 'new' : 'high'}`}>
+                        <span
+                          className={`machine-sticker ${
+                            index % 2 === 0 ? 'new' : 'high'
+                          }`}
+                        >
                           {index % 2 === 0 ? 'NEW' : 'HIGH SCORE'}
                         </span>
+
                         <span
                           className="arcade-play-btn"
                           onClick={(event) => {
                             event.stopPropagation()
-                            playCard(card.reward)
+                            playCard(card)
                           }}
                         >
                           Play
@@ -371,43 +552,87 @@ arcadeState.current = { isJumping, controlsLocked };
               <article className="live-panel glass-card">
                 <header>
                   <h3>{highScoreLabel}</h3>
+
                   <div className="live-stats">
                     <span className="score-value">Score: {score}</span>
+
                     <span className="health-pill">
                       <Heart size={14} /> {health}%
                     </span>
                   </div>
                 </header>
 
-                <div className="game-screen" role="img" aria-label="Mini platformer area">
+                <div
+                  className="game-screen"
+                  role="img"
+                  aria-label="Mini platformer area"
+                >
                   <div className="scanlines" />
+
                   <div className="platform" />
+
                   <div
                     className="player-sprite"
-                    style={{ left: `${playerX}%`, bottom: `${16 + jumpOffset}px` }}
+                    style={{
+                      left: `${playerX}%`,
+                      bottom: `${16 + jumpOffset}px`,
+                    }}
                   />
+
                   <div className="enemy enemy-a" />
                   <div className="enemy enemy-b" />
                 </div>
 
                 <div className="health-track">
-                  <div className="health-fill" style={{ width: `${health}%` }} />
+                  <div
+                    className="health-fill"
+                    style={{ width: `${health}%` }}
+                  />
                 </div>
 
                 <div className="controls-row">
-                  <button type="button" onClick={() => !controlsLocked && setPlayerX((prev) => clamp(prev - 7, 0, 88))}>Move ◀</button>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      !controlsLocked &&
+                      setPlayerX((prev) => clamp(prev - 7, 0, 88))
+                    }
+                  >
+                    Move ◀
+                  </button>
+
                   <button type="button" onClick={onJump}>
                     Jump ▲
                   </button>
-                  <button type="button" onClick={() => !controlsLocked && setPlayerX((prev) => clamp(prev + 7, 0, 88))}>Move ▶</button>
+
+                  <button
+                    type="button"
+                    onClick={() =>
+                      !controlsLocked &&
+                      setPlayerX((prev) => clamp(prev + 7, 0, 88))
+                    }
+                  >
+                    Move ▶
+                  </button>
                 </div>
 
                 <div className="panel-actions">
-                  <button type="button" className="btn-ghost" onClick={() => setIsPaused((prev) => !prev)}>
-                    <Pause size={14} /> {isPaused ? 'Resume' : 'Pause'}
+                  <button
+                    type="button"
+                    className="btn-ghost"
+                    onClick={() => setIsPaused((prev) => !prev)}
+                  >
+                    <Pause size={14} />
+                    {isPaused ? 'Resume' : 'Pause'}
                   </button>
-                  <button type="button" className="btn-ghost" onClick={() => setSoundOn((prev) => !prev)}>
-                    {soundOn ? <Volume2 size={14} /> : <VolumeX size={14} />} {soundOn ? 'Sound On' : 'Muted'}
+
+                  <button
+                    type="button"
+                    className="btn-ghost"
+                    onClick={() => setSoundOn((prev) => !prev)}
+                  >
+                    {soundOn ? <Volume2 size={14} /> : <VolumeX size={14} />}
+                    {soundOn ? 'Sound On' : 'Muted'}
                   </button>
                 </div>
               </article>
@@ -416,20 +641,28 @@ arcadeState.current = { isJumping, controlsLocked };
             <section className="bottom-row glass-card">
               <div className="xp-block">
                 <div className="row-title">Progress / XP</div>
+
                 <div className="xp-track">
-                  <div className="xp-fill" style={{ width: `${xp}%` }} />
+                  <div
+                    className="xp-fill"
+                    style={{ width: `${xp}%` }}
+                  />
                 </div>
               </div>
+
               <div className="rewards-block">
                 <div className="row-title">Recent Rewards</div>
+
                 <ul>
                   {rewards.map((reward) => (
                     <li key={reward}>{reward}</li>
                   ))}
                 </ul>
               </div>
+
               <div className="streak-block">
                 <div className="row-title">Current Streak</div>
+
                 <strong>
                   <Flame size={16} /> {streak} days
                 </strong>
@@ -442,14 +675,21 @@ arcadeState.current = { isJumping, controlsLocked };
               <header>
                 <Trophy size={16} /> Live Leaderboard
               </header>
+
               <ol className="leader-list">
-                {(leaderboard.length ? leaderboard : [
-                  { id: 'fallback-zp', name: 'ZeroPing', score: 11940 },
-                  { id: 'fallback-you', name: 'You', score },
-                  { id: 'fallback-kk', name: 'KatanaKid', score: 10885 },
-                ]).map((row, index) => (
+                {(leaderboard.length
+                  ? leaderboard
+                  : [
+                      { id: 'fallback-zp', name: 'ZeroPing', score: 11940 },
+                      { id: 'fallback-you', name: 'You', score },
+                      { id: 'fallback-kk', name: 'KatanaKid', score: 10885 },
+                    ]
+                ).map((row, index) => (
                   <li key={row.id}>
-                    <span>{index + 1}. {row.name}</span>
+                    <span>
+                      {index + 1}. {row.name}
+                    </span>
+
                     <strong>{row.score.toLocaleString()}</strong>
                   </li>
                 ))}
@@ -460,14 +700,18 @@ arcadeState.current = { isJumping, controlsLocked };
               <header>
                 <Users size={16} /> Friends Online
               </header>
+
               <ul className="friends-list">
                 {friends.map((friend) => (
                   <li key={friend.name}>
                     <span className="dot" />
+
                     <div>
                       <strong>{friend.name}</strong>
+
                       <span>{friend.status}</span>
                     </div>
+
                     <small>{friend.ping}ms</small>
                   </li>
                 ))}
@@ -477,16 +721,41 @@ arcadeState.current = { isJumping, controlsLocked };
             {activeTab === 'Multiplayer Arena' && (
               <section className="right-card glass-card arena-card">
                 <header>Arena Session</header>
-                <div className="arena-meta">Status: {isConnected ? 'Connected' : 'Disconnected'} | Reconnects: {reconnectCount}</div>
-                <div className="arena-actions">
-                  <button type="button" className="btn-ghost" onClick={leaveArena}>Leave</button>
-                  <button type="button" className="btn-ghost" onClick={reconnectArena}>Reconnect</button>
+
+                <div className="arena-meta">
+                  Status: {isConnected ? 'Connected' : 'Disconnected'} |
+                  Reconnects: {reconnectCount}
                 </div>
+
+                <div className="arena-actions">
+                  <button
+                    type="button"
+                    className="btn-ghost"
+                    onClick={leaveArena}
+                  >
+                    Leave
+                  </button>
+
+                  <button
+                    type="button"
+                    className="btn-ghost"
+                    onClick={reconnectArena}
+                  >
+                    Reconnect
+                  </button>
+                </div>
+
                 <ul className="arena-players">
                   {players.map((player) => (
-                    <li key={player.id} className={!player.connected ? 'ghost' : ''}>
+                    <li
+                      key={player.id}
+                      className={!player.connected ? 'ghost' : ''}
+                    >
                       <span>{player.name}</span>
-                      <small>{player.connected ? 'online' : 'left'}</small>
+
+                      <small>
+                        {player.connected ? 'online' : 'left'}
+                      </small>
                     </li>
                   ))}
                 </ul>
@@ -495,13 +764,16 @@ arcadeState.current = { isJumping, controlsLocked };
 
             <section className="right-card glass-card">
               <header>Daily Missions</header>
+
               <ul className="missions-list">
                 {missions.map((mission) => (
                   <li key={mission.label}>
                     <div className="mission-row">
                       <span>{mission.label}</span>
+
                       <strong>{mission.reward}</strong>
                     </div>
+
                     <div className="mission-track">
                       <div style={{ width: `${mission.progress}%` }} />
                     </div>
@@ -512,6 +784,7 @@ arcadeState.current = { isJumping, controlsLocked };
 
             <section className="right-card glass-card coins-badge glitch-flicker-soft">
               Saved Coins
+
               <strong>{coins.toLocaleString()}</strong>
             </section>
           </aside>


### PR DESCRIPTION
Closes #105 

### Bug found
Clicking Play on arcade cabinets only updated coins/xp and showed a placeholder state. No interactive game session opened for the selected cabinet.

### Root cause

1. `playCard()` only handled rewards and score updates.  
2. No active game state was being stored, so the UI never rendered a playable session component.

### Fix applied

1. Added `activeGame` state and updated cabinet click handlers to pass the full card object instead of only reward values.
2. Updated `playCard()` to:
- set active game
- start game session
-  switch to mini games view
3. Added conditional rendering for interactive gameplay screen using selected cabinet data.


### Testing done

1. Reproduced the bug before applying fix
2. Confirmed fix resolves the issue
3. Verified existing features are not broken
4. Tested on Chrome 147/1920 x 1080  desktop

### Screenshots (before / after)
- Before:
On clicking play on neon runner displays the stale state:
<img width="1600" height="833" alt="image" src="https://github.com/user-attachments/assets/6f3df8f5-ec68-430d-9a7e-5d276e222ca3" />

After:
On clicking play on neon runner displays the interactive game-playing screen:
<img width="1919" height="993" alt="image" src="https://github.com/user-attachments/assets/a2324709-c20d-4f74-8ef5-4896fbffcb95" />

