### PR TITLE
Infinite coin and XP farming via Arcade game cards #106

### DIFF
--- a/src/components/ArcadeHouse.jsx
+++ b/src/components/ArcadeHouse.jsx
@@ -191,18 +191,23 @@ arcadeState.current = { isJumping, controlsLocked };
 
   const jumpOffset = isJumping ? Math.max(0, Math.sin((jumpTick / 6) * Math.PI) * 56) : 0
 
-  const playCard = (reward) => {
-    setIsJumping(false);
-  setJumpTick(0);
-    setCoins((prev) => prev + reward)
-    setScore((prev) => prev + reward)
-    setXp((prev) => clamp(prev + 4, 0, 100))
-    if (Math.random() > 0.7) {
-      setStreak((prev) => prev + 1)
-    }
+  const isLaunching = useRef(false)
+
+  const playCard = () => {
+    if (isLaunching.current) return
+    isLaunching.current = true
+    
+    setIsJumping(false)
+    setJumpTick(0)
+    setGameStarted(true)
+    
+    setTimeout(() => {
+      isLaunching.current = false
+    }, 1000)
   }
 
   const onStartGame = () => {
+    if (gameStarted) return
     setGameStarted(true)
     setScore((prev) => prev + 40)
   }
@@ -338,7 +343,7 @@ arcadeState.current = { isJumping, controlsLocked };
                       key={card.id}
                       type="button"
                       className="arcade-machine"
-                      onClick={() => playCard(card.reward)}
+                      onClick={() => playCard()}
                     >
                       <div className="machine-marquee">{card.title}</div>
                       <div className={`machine-screen ${index % 3 === 0 ? 'glitch-flicker-soft' : ''}`}>
@@ -357,7 +362,7 @@ arcadeState.current = { isJumping, controlsLocked };
                           className="arcade-play-btn"
                           onClick={(event) => {
                             event.stopPropagation()
-                            playCard(card.reward)
+                            playCard()
                           }}
                         >
                           Play


### PR DESCRIPTION
Pull Request: Fix Arcade Card Farming Exploit

Closes issue number #106 

Problem Description:
Players were able to exploit the "Play" button on Arcade machine cards by clicking them rapidly. This resulted in:

1. Instant increment of coins, score, and XP without entering the game loop.
2. Inflation of player stats (streaks, progress) through repeated button triggers.
3. Potential race conditions in state updates due to overlapping game start sequences.

Solution:
Implemented a cooldown mechanism and secured the playCard function to ensure integrity:

1. Launch Cooldown: Added an isLaunching ref to track the state of a game launch.
2. Debouncing Logic: Modified playCard to return immediately if a launch is already in progress.
3. State Protection: Ensured the function only initializes the game state (setGameStarted(true)) and does not directly mutate reward states (coins, score, XP).
4. Cooldown Reset: Included a 1000ms timeout to reset the launch lock, allowing for subsequent legitimate game starts while blocking rapid exploits.

Changes
ArcadeHouse.jsx
Added isLaunching useRef.
Updated playCard function with cooldown logic.

Verification Steps
1. Navigate to the Arcade House.
2. Locate the Virtual Arcade Hall section.
3. Rapidly and repeatedly click the Play button on any game card (e.g., Neon Runner).

Expected Result:
1. Coins, Score, and XP should not increase on click.
2. The game should transition to the "started" state correctly.
3. Subsequent clicks within the 1-second cooldown window should be ignored.